### PR TITLE
Save test predictions to file

### DIFF
--- a/neural/model.py
+++ b/neural/model.py
@@ -137,7 +137,7 @@ class BertEmbedder(nn.Module):
                                                     output_all_encoded_layers=self.bert_all_output)
                 embed_layers_lst.append(encoded_layers)
 
-        # embed all sentences at once
+        # # embed all sentences at once
         # with torch.set_grad_enabled(self.bert_train_flag):
         #     encoded_layers, __ = self.bertmodel(doc_tensor, attention_mask=attention_mask,
         #                                         output_all_encoded_layers=self.bert_all_output)

--- a/neural/model.py
+++ b/neural/model.py
@@ -127,27 +127,27 @@ class BertEmbedder(nn.Module):
         TODO: add flags and logic to handle multiple layers embedding (i.e. 12 layers embedding)
         '''
 
-        # embed_layers_lst = []
-        #
-        # for sent_indx in range(num_sents):  # going over each sentenece one by one due to GPU limit :((
-        #     # print('sent_indx', sent_indx)
-        #     with torch.set_grad_enabled(self.bert_train_flag):
-        #         encoded_layers, __ = self.bertmodel(doc_tensor[sent_indx:sent_indx+1],
-        #                                             attention_mask=attention_mask[sent_indx:sent_indx+1],
-        #                                             output_all_encoded_layers=self.bert_all_output)
-        #         embed_layers_lst.append(encoded_layers)
+        embed_layers_lst = []
+
+        for sent_indx in range(num_sents):  # going over each sentenece one by one due to GPU limit :((
+            # print('sent_indx', sent_indx)
+            with torch.set_grad_enabled(self.bert_train_flag):
+                encoded_layers, __ = self.bertmodel(doc_tensor[sent_indx:sent_indx+1],
+                                                    attention_mask=attention_mask[sent_indx:sent_indx+1],
+                                                    output_all_encoded_layers=self.bert_all_output)
+                embed_layers_lst.append(encoded_layers)
 
         # embed all sentences at once
-        with torch.set_grad_enabled(self.bert_train_flag):
-            encoded_layers, __ = self.bertmodel(doc_tensor, attention_mask=attention_mask,
-                                                output_all_encoded_layers=self.bert_all_output)
+        # with torch.set_grad_enabled(self.bert_train_flag):
+        #     encoded_layers, __ = self.bertmodel(doc_tensor, attention_mask=attention_mask,
+        #                                         output_all_encoded_layers=self.bert_all_output)
+        #
+        # return encoded_layers
 
-        return encoded_layers
-
-        # # concat everything
-        # out = torch.cat(embed_layers_lst, dim=0)
-        # # print("finished embedding sents using BERT!")
-        # return out
+        # concat everything
+        out = torch.cat(embed_layers_lst, dim=0)
+        # print("finished embedding sents using BERT!")
+        return out
 
 
 class SentenceEncoder(nn.Module):

--- a/neural/neural_discern_run_script.py
+++ b/neural/neural_discern_run_script.py
@@ -226,44 +226,20 @@ if __name__ == '__main__':
                                                                                       "autodiscern/aa_neural/")
     args = parser.parse_args()
 
-    # config = {
-    #     'test_mode': args.test_mode,
-    #     'biobert': args.biobert,
-    #     'rewrite_sentence_embeddings': args.rewrite_sentence_embeddings,
-    #     'run_hyper_param_search': args.run_hyper_param_search,
-    #     'hyperparam_search_dir': args.hyperparam_search_dir,
-    #     'experiment_to_rerun': args.experiment_to_rerun,
-    #     'copy_exp_dir': args.copy_exp_dir,
-    #     'questions_to_run': [4, 5, 9, 10, 11],
-    #     'max_folds': 5,
-    #     'num_epochs': 25,
-    #     'verbose': True,
-    #     'questions': (4, 5, 9, 10, 11),
-    #     'question_gpu_map': {4: 1, 5: 2, 9: 3, 10: 4, 11: 5},
-    #     'base_dir': args.base_dir,
-    # }
-
     config = {
-        'test_mode': False,
-        'biobert': True,
-        'rewrite_sentence_embeddings': False,
-        'run_hyper_param_search': False,
-        # 'hyperparam_search_dir': os.path.join(args.base_dir, 'experiments', '2019-10-08_14-54-50',
-        # 'train_validation'),
-        'hyperparam_search_dir': None,
-        'questions_to_run': [4],  # , 5, 9, 10, 11],
-        'max_folds': 1,
-        'num_epochs': 2,
+        'test_mode': args.test_mode,
+        'biobert': args.biobert,
+        'rewrite_sentence_embeddings': args.rewrite_sentence_embeddings,
+        'run_hyper_param_search': args.run_hyper_param_search,
+        'hyperparam_search_dir': args.hyperparam_search_dir,
+        'experiment_to_rerun': args.experiment_to_rerun,
+        'copy_exp_dir': args.copy_exp_dir,
+        'questions_to_run': [4, 5, 9, 10, 11],
+        'max_folds': 5,
+        'num_epochs': 25,
         'verbose': True,
-        # 'experiment_to_rerun': 'tests/2019-11-08_12-17-13',
-        # 'experiment_to_rerun': 'debug_aa',
-        # 'experiment_to_rerun': '2019-11-14_09-05-21',
-        # 'experiment_to_rerun': '2019-10-08_14-54-50',  # bert dir
-        'experiment_to_rerun': '2019-10-08_14-54-50_rerun_2019-11-14_09-38-59',  # bert re-run dir
-        # 'experiment_to_rerun': '2019-10-28_15-59-09',  # biobert
-        'copy_exp_dir': False,
         'questions': (4, 5, 9, 10, 11),
-        'question_gpu_map': {4: 2, 5: 2, 9: 3, 10: 4, 11: 5},
+        'question_gpu_map': {4: 1, 5: 2, 9: 3, 10: 4, 11: 5},
         'base_dir': args.base_dir,
     }
 
@@ -284,8 +260,6 @@ if __name__ == '__main__':
             rerun_dir_name = '{}_{}_{}'.format(config['experiment_to_rerun'], 'rerun', time_stamp)
             orig_exp_dir = os.path.join(config['base_dir'], 'experiments', config['experiment_to_rerun'])
             exp_dir = os.path.join(config['base_dir'], 'experiments', rerun_dir_name)
-            # orig_exp_dir = os.path.join(config['base_dir'], config['experiment_to_rerun'])
-            # exp_dir = os.path.join(config['base_dir'], rerun_dir_name)
             create_directory(exp_dir)
             # copy contents of original exp dir so experiment re-run has everything it needs
             print("copying experiment for re-run in {}...".format(exp_dir))
@@ -293,7 +267,6 @@ if __name__ == '__main__':
             print("... complete")
         else:
             exp_dir = exp_dir = os.path.join(config['base_dir'], 'experiments', config['experiment_to_rerun'])
-            # exp_dir = exp_dir = os.path.join(config['base_dir'], config['experiment_to_rerun'])
 
     else:
         if config['test_mode']:
@@ -365,13 +338,13 @@ if __name__ == '__main__':
 
     verbose_print("Training...", verbose)
     train_val_dir = create_directory('train_validation', exp_dir)
-    # train_val_dir = run_training_parallel(config['questions_to_run'], train_val_dir, q_docpartitions, q_config_map,
-    #                                       bertmodel, config['sents_embed_dir'], config['question_gpu_map'],
-    #                                       config['num_epochs'], config['max_folds'])
+    train_val_dir = run_training_parallel(config['questions_to_run'], train_val_dir, q_docpartitions, q_config_map,
+                                          bertmodel, config['sents_embed_dir'], config['question_gpu_map'],
+                                          config['num_epochs'], config['max_folds'])
 
     verbose_print("Evaluating on test set...", verbose)
     test_dir = evaluate_on_test_set(config['exp_dir'], q_docpartitions, q_config_map, bertmodel, train_val_dir,
-                                    config['sents_embed_dir'], gpu_index=2)
+                                    config['sents_embed_dir'], gpu_index=1)
 
     micro_f1_df, macro_f1_df, accuracy_df = build_accuracy_dfs(q_docpartitions, test_dir)
     print("micro_f1_df: {}".format(micro_f1_df))

--- a/neural/neural_discern_run_script.py
+++ b/neural/neural_discern_run_script.py
@@ -242,14 +242,31 @@ if __name__ == '__main__':
         'base_dir': args.base_dir,
     }
 
+    # config = {
+    #     'test_mode': False,
+    #     'biobert': False,
+    #     'rewrite_sentence_embeddings': False,
+    #     'run_hyper_param_search': False,
+    #     'hyperparam_search_dir': None,
+    #     'questions_to_run': [4],  #, 5, 9, 10, 11],
+    #     'max_folds': 5,
+    #     'num_epochs': 25,
+    #     'verbose': True,
+    #     'experiment_to_rerun': 'tests/2019-11-08_12-17-13',
+    #     'copy_exp_dir': True,
+    #     'questions': (4, 5, 9, 10, 11),
+    #     'question_gpu_map': {4: 1, 5: 2, 9: 3, 10: 4, 11: 5},
+    #     'base_dir': args.base_dir,
+    # }
+
     if config['hyperparam_search_dir'] and config['run_hyper_param_search']:
         print("WARNING: you selected a hyperparam search dir while also setting run-hyper-param-search as True. "
               "The pre-built hyperparam search dir will be used. Hyperparam search will not be run.")
 
     # under test mode (for faster debugging), run a smaller set of partitions and epochs, and no hyper param search
     if config['test_mode']:
-        config['max_folds'] = 2  # max number of data partition folds to run (for faster testing)
-        config['num_epochs'] = 2
+        config['max_folds'] = 1  # max number of data partition folds to run (for faster testing)
+        config['num_epochs'] = 1
         config['run_hyper_param_search'] = False
 
     time_stamp = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')

--- a/neural/neural_discern_run_script.py
+++ b/neural/neural_discern_run_script.py
@@ -264,7 +264,6 @@ if __name__ == '__main__':
             print("... complete")
         else:
             exp_dir = exp_dir = os.path.join(config['base_dir'], 'experiments', config['experiment_to_rerun'])
-
     else:
         if config['test_mode']:
             exp_dir = os.path.join(config['base_dir'], 'experiments', 'tests', time_stamp)

--- a/neural/neural_discern_run_script.py
+++ b/neural/neural_discern_run_script.py
@@ -259,9 +259,9 @@ if __name__ == '__main__':
         # 'experiment_to_rerun': 'debug_aa',
         # 'experiment_to_rerun': '2019-11-14_09-05-21',
         # 'experiment_to_rerun': '2019-10-08_14-54-50',  # bert dir
-        # 'experiment_to_rerun': '2019-10-08_14-54-50_rerun_2019-11-14_09-38-59',  # bert re-run dir
-        'experiment_to_rerun': '2019-10-28_15-59-09',  # biobert
-        'copy_exp_dir': True,
+        'experiment_to_rerun': '2019-10-08_14-54-50_rerun_2019-11-14_09-38-59',  # bert re-run dir
+        # 'experiment_to_rerun': '2019-10-28_15-59-09',  # biobert
+        'copy_exp_dir': False,
         'questions': (4, 5, 9, 10, 11),
         'question_gpu_map': {4: 2, 5: 2, 9: 3, 10: 4, 11: 5},
         'base_dir': args.base_dir,
@@ -341,7 +341,7 @@ if __name__ == '__main__':
         write_sents_embeddings(config['base_dir'], bertmodel, config['sents_embed_dir_name'], docs_data_tensor)
 
     if config['experiment_to_rerun']:
-        verbose_print("Using hyper-parameter search results from {}".format(config['hyperparam_search_dir']), verbose)
+        verbose_print("Using hyper-parameter search results from {}".format(config['exp_dir']), verbose)
         hyperparam_search_dir = os.path.join(config['exp_dir'], 'train_validation')
         q_config_map = build_q_config_map_from_train_val(hyperparam_search_dir, config['questions'])
     elif config['run_hyper_param_search']:

--- a/neural/neural_discern_run_script.py
+++ b/neural/neural_discern_run_script.py
@@ -216,10 +216,8 @@ if __name__ == '__main__':
     parser.add_argument("--rewrite-sentence-embeddings", action="store_true", default=False, help="(Re-)compute the "
                                                                                                   "sentence embeddings")
     parser.add_argument("--run-hyper-param-search", default=True, help="Run the hyper parameter search")
-    parser.add_argument("--hyperparam-search-dir", default=None, help="Re-use the results of a pre-run hyperparam "
-                                                                      "search")
     parser.add_argument("--experiment-to-rerun", default=None, help="Experiment directory to use as a basis for a "
-                                                                    "re-run")
+                                                                    "re-run (will use same hyperparams)")
     parser.add_argument("--copy-exp-dir", default=True, help='Whether to make a copy of the experiment dir to re-run, '
                                                              'so as not to overwrite the current one. ')
     parser.add_argument("--base-dir", default='/opt/data/autodiscern/aa_neural', help="Base dir to and including "
@@ -231,7 +229,6 @@ if __name__ == '__main__':
         'biobert': args.biobert,
         'rewrite_sentence_embeddings': args.rewrite_sentence_embeddings,
         'run_hyper_param_search': args.run_hyper_param_search,
-        'hyperparam_search_dir': args.hyperparam_search_dir,
         'experiment_to_rerun': args.experiment_to_rerun,
         'copy_exp_dir': args.copy_exp_dir,
         'questions_to_run': [4, 5, 9, 10, 11],
@@ -243,9 +240,9 @@ if __name__ == '__main__':
         'base_dir': args.base_dir,
     }
 
-    if config['hyperparam_search_dir'] and config['run_hyper_param_search']:
-        print("WARNING: you selected a hyperparam search dir while also setting run-hyper-param-search as True. "
-              "The pre-built hyperparam search dir will be used. Hyperparam search will not be run.")
+    if config['experiment_to_rerun'] and config['run_hyper_param_search']:
+        print("WARNING: you selected a experiment_to_rerun while also setting run-hyper-param-search as True. "
+              "The pre-built experiment_to_rerun will be used. Hyperparam search will not be run.")
 
     # under test mode (for faster debugging), run a smaller set of partitions and epochs, and no hyper param search
     if config['test_mode']:

--- a/neural/neural_discern_run_script.py
+++ b/neural/neural_discern_run_script.py
@@ -225,39 +225,39 @@ if __name__ == '__main__':
                                                                                       "autodiscern/aa_neural/")
     args = parser.parse_args()
 
-    config = {
-        'test_mode': args.test_mode,
-        'biobert': args.biobert,
-        'rewrite_sentence_embeddings': args.rewrite_sentence_embeddings,
-        'run_hyper_param_search': args.run_hyper_param_search,
-        'hyperparam_search_dir': args.hyperparam_search_dir,
-        'experiment_to_rerun': args.experiment_to_rerun,
-        'copy_exp_dir': args.copy_exp_dir,
-        'questions_to_run': [4, 5, 9, 10, 11],
-        'max_folds': 5,
-        'num_epochs': 25,
-        'verbose': True,
-        'questions': (4, 5, 9, 10, 11),
-        'question_gpu_map': {4: 1, 5: 2, 9: 3, 10: 4, 11: 5},
-        'base_dir': args.base_dir,
-    }
-
     # config = {
-    #     'test_mode': False,
-    #     'biobert': False,
-    #     'rewrite_sentence_embeddings': False,
-    #     'run_hyper_param_search': False,
-    #     'hyperparam_search_dir': None,
-    #     'questions_to_run': [4],  #, 5, 9, 10, 11],
+    #     'test_mode': args.test_mode,
+    #     'biobert': args.biobert,
+    #     'rewrite_sentence_embeddings': args.rewrite_sentence_embeddings,
+    #     'run_hyper_param_search': args.run_hyper_param_search,
+    #     'hyperparam_search_dir': args.hyperparam_search_dir,
+    #     'experiment_to_rerun': args.experiment_to_rerun,
+    #     'copy_exp_dir': args.copy_exp_dir,
+    #     'questions_to_run': [4, 5, 9, 10, 11],
     #     'max_folds': 5,
     #     'num_epochs': 25,
     #     'verbose': True,
-    #     'experiment_to_rerun': 'tests/2019-11-08_12-17-13',
-    #     'copy_exp_dir': True,
     #     'questions': (4, 5, 9, 10, 11),
     #     'question_gpu_map': {4: 1, 5: 2, 9: 3, 10: 4, 11: 5},
     #     'base_dir': args.base_dir,
     # }
+
+    config = {
+        'test_mode': False,
+        'biobert': False,
+        'rewrite_sentence_embeddings': False,
+        'run_hyper_param_search': False,
+        'hyperparam_search_dir': None,
+        'questions_to_run': [4],  #, 5, 9, 10, 11],
+        'max_folds': 1,
+        'num_epochs': 25,
+        'verbose': True,
+        'experiment_to_rerun': 'debug_aa',
+        'copy_exp_dir': True,
+        'questions': (4, 5, 9, 10, 11),
+        'question_gpu_map': {4: 2, 5: 2, 9: 3, 10: 4, 11: 5},
+        'base_dir': args.base_dir,
+    }
 
     if config['hyperparam_search_dir'] and config['run_hyper_param_search']:
         print("WARNING: you selected a hyperparam search dir while also setting run-hyper-param-search as True. "
@@ -274,15 +274,19 @@ if __name__ == '__main__':
         if config['copy_exp_dir']:
             from distutils.dir_util import copy_tree
             rerun_dir_name = '{}_{}_{}'.format(config['experiment_to_rerun'], 'rerun', time_stamp)
-            orig_exp_dir = os.path.join(config['base_dir'], 'experiments', config['experiment_to_rerun'])
-            exp_dir = os.path.join(config['base_dir'], 'experiments', rerun_dir_name)
+            # orig_exp_dir = os.path.join(config['base_dir'], 'experiments', config['experiment_to_rerun'])
+            # exp_dir = os.path.join(config['base_dir'], 'experiments', rerun_dir_name)
+            orig_exp_dir = os.path.join(config['base_dir'], config['experiment_to_rerun'])
+            exp_dir = os.path.join(config['base_dir'], rerun_dir_name)
             create_directory(exp_dir)
             # copy contents of original exp dir so experiment re-run has everything it needs
             print("copying experiment for re-run in {}...".format(exp_dir))
             copy_tree(orig_exp_dir, exp_dir)
             print("... complete")
         else:
-            exp_dir = exp_dir = os.path.join(config['base_dir'], 'experiments', config['experiment_to_rerun'])
+            # exp_dir = exp_dir = os.path.join(config['base_dir'], 'experiments', config['experiment_to_rerun'])
+            exp_dir = exp_dir = os.path.join(config['base_dir'], config['experiment_to_rerun'])
+
     else:
         if config['test_mode']:
             exp_dir = os.path.join(config['base_dir'], 'experiments', 'tests', time_stamp)
@@ -353,13 +357,13 @@ if __name__ == '__main__':
 
     verbose_print("Training...", verbose)
     train_val_dir = create_directory('train_validation', exp_dir)
-    train_val_dir = run_training_parallel(config['questions_to_run'], train_val_dir, q_docpartitions, q_config_map,
-                                          bertmodel, config['sents_embed_dir'], config['question_gpu_map'],
-                                          config['num_epochs'], config['max_folds'])
+    # train_val_dir = run_training_parallel(config['questions_to_run'], train_val_dir, q_docpartitions, q_config_map,
+    #                                       bertmodel, config['sents_embed_dir'], config['question_gpu_map'],
+    #                                       config['num_epochs'], config['max_folds'])
 
     verbose_print("Evaluating on test set...", verbose)
     test_dir = evaluate_on_test_set(config['exp_dir'], q_docpartitions, q_config_map, bertmodel, train_val_dir,
-                                    config['sents_embed_dir'], gpu_index=1)
+                                    config['sents_embed_dir'], gpu_index=2)
 
     micro_f1_df, macro_f1_df, accuracy_df = build_accuracy_dfs(q_docpartitions, test_dir)
     print("micro_f1_df: {}".format(micro_f1_df))

--- a/neural/predict_with_neural.py
+++ b/neural/predict_with_neural.py
@@ -83,12 +83,13 @@ def embed_sentences(docs_data_tensor, sents_embed_path, bertmodel, bert_config, 
 
 def biobert_predict(data_dict: dict):
     """
-    Make a prediction for an article data_dict
+    Make an autoDiscern prediction for an article data_dict using the HEA BioBERT model. Includes all of the data
+    preprocessing steps as were applied for the training of the HEA BioBERT model.
 
     Args:
-        data_dict: dictionary of {id: sib-dict}, with sub-dictionary with keys ['url', 'content', 'id']
+        data_dict: dictionary of {id: sib-dict}, with sub-dictionary with keys ['url', 'content', 'id', 'responses']
 
-    Returns: autodiscern predictions for the article
+    Returns: autodiscern predictions for the article.
 
     """
 
@@ -96,22 +97,20 @@ def biobert_predict(data_dict: dict):
     to_gpu = True
     gpu_index = 3
     fold_num = 0
-    working_dir = 'predict'  # TODO
+    working_dir = 'predict'
     # experiment_dir = '2019-10-14_14-41-53'
     experiment_dir = '2019-10-08_14-54-50'
 
     vocab_path = os.path.join(base_dir, 'aa_neural/aws_downloads/bert-base-cased-vocab.txt')
-    # TODO: load config from filesystem?
     processor_config = {'tokenizer_max_sent_len': 300,
                         'label_cutoff': 3,
                         'label_avgmethod': 'round_mean'}
 
-    sents_embed_dir = os.path.join(base_dir, 'aa_neural/sents_bert_embed_cased')  # TODO
-    # TODO: load from filesystem?
+    sents_embed_dir = os.path.join(base_dir, 'aa_neural/sents_bert_embed_cased')
     bert_config = {'bert_train_flag': False,
                    'bert_all_output': False}
 
-    state_dict_path_form = 'train_validation/question_{}/fold_0/model_statedict/'  # TODO QUESTION:  why not in test?
+    state_dict_path_form = 'train_validation/question_{}/fold_0/model_statedict/'
     config_path_form = 'test/question_{}/fold_0/config/'
 
     default_device = get_device(to_gpu=False)
@@ -179,8 +178,15 @@ def biobert_predict(data_dict: dict):
 
 
 def build_data_dict(url, content):
-    fake_responses = pd.DataFrame({'fake responses': [0]*12})  # is this supposed to be a len 5 or 11 list?
-    # TODO: Q:question is used as index, not sure if that means list needs to be 11 long, or questions are actually 0-4
+    """Format the html information in a data_dict as required for the prediction routine.
+
+    Args:
+        url: url of the article
+        content: html contents of the article
+
+    Returns: Dict
+    """
+    fake_responses = pd.DataFrame({'fake responses': [0]*5})
     data_dict = {0: {'id': 0,
                      'url': url,
                      'content': content,
@@ -191,12 +197,28 @@ def build_data_dict(url, content):
 
 
 def make_prediction(url: str):
+    """
+    End to end function for making an autoDiscern prediction for a given url.
+
+    Args:
+        url: url of the article to make predictions for
+
+    Returns: autoDiscern predictions for the article
+
+    """
     html_content = retrieve_page_from_internet(url)
     data_dict = build_data_dict(url, html_content)
     return biobert_predict(data_dict)
 
 
 def test_make_prediction():
+    """
+    End to end test function for making an autoDiscern prediction, without relying on an internet connection.
+    Relies on a the existence of a test.html file.
+
+    Returns: autoDiscern predictions for the article
+
+    """
     test_data_path = os.path.join(BASE_DIR, 'data', 'test.html')
     test_article_url = 'https://www.nhs.uk/conditions/tendonitis/'
 

--- a/neural/run_workflow.py
+++ b/neural/run_workflow.py
@@ -218,8 +218,10 @@ def run_neural_discern(data_partition, dsettypes, bertmodel, config, options, wr
     docid_attnweights_map = {dsettype: {} for dsettype in data_loaders if dsettype in {'validation', 'test'}}
     # store sentences' attention weights
 
-    if('validation' in data_loaders):
-        m_state_dict_dir = create_directory(os.path.join(wrk_dir, 'model_statedict'))
+    # LKK: i think putting this variable init behind a conditional is unecessary?
+    # if 'validation' in data_loaders :
+    #     m_state_dict_dir = create_directory(os.path.join(wrk_dir, 'model_statedict'))
+    m_state_dict_dir = create_directory(os.path.join(wrk_dir, 'model_statedict'))
 
     if(num_epochs > 1):
         fig_dir = create_directory(os.path.join(wrk_dir, 'figures'))
@@ -370,6 +372,11 @@ def run_neural_discern(data_partition, dsettypes, bertmodel, config, options, wr
                     # dump attention weights for the validation data
                     dump_dict_content(docid_attnweights_map, ['test'], 'docid_attnw_map', wrk_dir)
 
+            # LKK added this to debug prediction mismatch
+            if (dsettype == 'test'):
+                for m, m_name in models:
+                    torch.save(m.state_dict(), os.path.join(m_state_dict_dir, '{}.pkl'.format(m_name)))
+
     if(num_epochs > 1):
         plot_loss(epoch_loss_avgbatch, epoch_loss_avgsamples, fig_dir)
 
@@ -384,7 +391,7 @@ def run_neural_discern(data_partition, dsettypes, bertmodel, config, options, wr
         'id': doc_ids,
         'true_class': ref_class,
         'pred_class': pred_class,
-        # 'prob_scores': probability_scores,
+        'prob_scores': probability_scores,
         # 'attention_weight_map': docid_attnweights_map['test']
     }
     predictions_df = pd.DataFrame(df_dict)
@@ -589,10 +596,23 @@ def get_best_config_from_hyperparamsearch(questions, hyperparam_search_dir, num_
                 scores[config_num, 3] = mscore.accuracy
                 scores[config_num, 4] = mscore.auc
                 exist_flag = True
+            else:
+                print("WARNING: hyperparam search dir does not exist: {}".format(score_file))
         if(exist_flag):
             argmax_indx = get_index_argmax(scores, metric_indx)
             mconfig, options = get_saved_config(os.path.join(fold_dir, 'config_{}'.format(argmax_indx), 'config'))
             q_fold_config_map[question] = (mconfig, options, argmax_indx)
+    return q_fold_config_map
+
+
+def build_q_config_map_from_train_val(train_val_dir, questions=[4, 5, 9, 10, 11], folds=[0, 1, 2, 3, 4]):
+    print("GOT HERE YAY")
+    q_fold_config_map = {}
+    for question in questions:
+        for fold_num in folds:
+            fold_dir = os.path.join(train_val_dir, 'question_{}'.format(question), 'fold_{}'.format(fold_num))
+            mconfig, options = get_saved_config(os.path.join(fold_dir, 'config'))
+            q_fold_config_map[question] = (mconfig, options, -1)
     return q_fold_config_map
 
 
@@ -632,7 +652,7 @@ def train_val_run_one_question(queue, question, q_docpartitions, q_fold_config_m
 def test_run(q_docpartitions, q_fold_config_map, bertmodel, train_val_dir, test_dir, sents_embed_dir, gpu_index,
              num_epochs=1):
     dsettypes = ['test']
-    print(q_fold_config_map)
+    print('q_fold_config_map: {}'.format(q_fold_config_map))
     for question in q_fold_config_map:
         print("running q {}".format(question))
         mconfig, options, __ = q_fold_config_map[question]
@@ -652,9 +672,15 @@ def test_run(q_docpartitions, q_fold_config_map, bertmodel, train_val_dir, test_
                 path = os.path.join(test_dir, 'question_{}'.format(question), 'fold_{}'.format(fold_num))
                 test_wrk_dir = create_directory(path)
 
-                print('state_dict_pth: '.format(state_dict_pth))
+                print('state_dict_pth: {}'.format(state_dict_pth))
                 run_neural_discern(data_partition, dsettypes, bertmodel, mconfig, options, test_wrk_dir,
                                    sents_embed_dir, state_dict_dir=state_dict_pth, gpu_index=gpu_index)
+            else:
+                print('WARNING: test dir not found: {}'.format(path))
+            print("WARNING DEBUG BREAK!!")
+            break
+        print("WARNING DEBUG BREAK!!")
+        break
 
 # ==================================================
 

--- a/neural/run_workflow.py
+++ b/neural/run_workflow.py
@@ -245,7 +245,7 @@ def run_neural_discern(data_partition, dsettypes, bertmodel, config, options, wr
             pred_class = []
             ref_class = []
             doc_ids = []
-            probability_scores = []
+            all_probability_scores = []
 
             data_loader = data_loaders[dsettype]
             # total_num_samples = len(data_loader.dataset)
@@ -313,11 +313,11 @@ def run_neural_discern(data_partition, dsettypes, bertmodel, config, options, wr
                         logsoftmax_scores = doc_categ_scorer(doc_out)
                         __, pred_classindx = torch.max(logsoftmax_scores, 1)  # apply max on row level
 
-                        print('logsoftmax_scores', logsoftmax_scores.shape)
-                        print('pred_calssindx', pred_classindx.shape)
-                        print('ref labels', docs_labels[doc_indx, question].unsqueeze(0).shape)
-                        print('predicted class index:', pred_classindx.item())
-                        print('ref class index:', docs_labels[doc_indx, question].item())
+                        # print('logsoftmax_scores', logsoftmax_scores.shape)
+                        # print('pred_calssindx', pred_classindx.shape)
+                        # print('ref labels', docs_labels[doc_indx, question].unsqueeze(0).shape)
+                        # print('predicted class index:', pred_classindx.item())
+                        # print('ref class index:', docs_labels[doc_indx, question].item())
                         pred_class.append(pred_classindx.item())
                         ref_class.append(docs_labels[doc_indx, question].item())
 
@@ -328,7 +328,7 @@ def run_neural_discern(data_partition, dsettypes, bertmodel, config, options, wr
                     # finished processing docs in batch
                     b_logprob_scores = torch.cat(logprob_scores, dim=0)
                     b_target_class = torch.cat(target_class, dim=0)
-                    probability_scores.extend([t for t in b_logprob_scores])
+                    all_probability_scores.extend(logprob_scores)
                     # print("b_logprob_scores", b_logprob_scores.shape)
                     # print("b_target_class", b_target_class.shape)
                     loss = loss_func(b_logprob_scores, b_target_class)
@@ -383,7 +383,8 @@ def run_neural_discern(data_partition, dsettypes, bertmodel, config, options, wr
         'id': doc_ids,
         'true_class': ref_class,
         'pred_class': pred_class,
-        'prob_scores': probability_scores,
+        'logprob_score_class0': [t.data.cpu().numpy()[0][0] for t in all_probability_scores],
+        'logprob_score_class1': [t.data.cpu().numpy()[0][1] for t in all_probability_scores],
         # 'attention_weight_map': docid_attnweights_map['test']
     }
     predictions_df = pd.DataFrame(df_dict)

--- a/neural/run_workflow.py
+++ b/neural/run_workflow.py
@@ -151,6 +151,7 @@ def run_neural_discern(data_partition, dsettypes, bertmodel, config, options, wr
 
     # setup the models
     # bert model
+    bertmodel.to(device)
     bert_encoder = BertEmbedder(bertmodel, bertencoder_config)
     bert_train_flag = bertencoder_config.get('bert_train_flag', False)
     bert_encoder.type(fdtype).to(device)


### PR DESCRIPTION
* Saves the predictions made during model training and testing to `<wrk_dir>/predictions.csv`. 
  * The csv contains document id, true class, predicted class, and log probabilities for each class prediction. 
  * In addition to assisting with deugging and identifying example predictions, this data is used for simulating accuracy scores with at different levels of coverage (only making predictions when the model's prediction confidence is above a certain threshold). 
* Switches `hyperparam-search-dir` command line argument for `experiment-to-rerun`, which uses the config from that experiment's `train_validation question_*/fold_*/config/` directories (instead of repeating the search for best hyperparam search dir). 