### PR TITLE
Enable neural models to run on cpu-only machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,9 +69,6 @@ docs/_build/
 # PyBuilder
 target/
 
-# Jupyter Notebook
-.ipynb_checkpoints
-
 # pyenv
 .python-version
 
@@ -105,12 +102,22 @@ venv.bak/
 
 # Data
 data/
-package_data/public_mm_lite/*
-.csv
-.ipynb
+*.csv
+
+# Jupyter Notebook
+*.ipynb_checkpoints
+*.ipynb
 
 # Vs code
 .vscode
 
 # notes
 work_in_progress.txt
+.idea
+
+.DS_Store
+
+# Package Data not stored in Git
+autodiscern/package_data/predictors/*
+autodiscern/package_data/public_mm_lite/*
+autodiscern/package_data/pytorch_biobert/*

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Automating the application of the [DISCERN](http://www.discern.org.uk/index.php)
     * [The Published Model](#The-Published-Model)
   * [Training the Neural Models](#Training-the-Neural-Models)
 * [Model Deployment with the Web App](#Model-Deployment-with-the-Web-App)
+  * [Prepping Your Selected Model for Deployment](#Prepping-Your-Selected-Model-for-Deployment)
+  * [Deployment with Docker](#Deployment-with-Docker)
 * [Known issues](#Known-issues)
   * [Installing on Windows OS](#Installing-on-Windows-OS)
 
@@ -374,6 +376,47 @@ Note to self: This model was trained on LeoMed
 (`sing_dis; /opt/conda/bin/python neural_dicsern_run_script.py`)
 
 ## Model Deployment with the Web App
+
+### Prepping your Selected Model for Deployment
+To deploy a model, that model's `<experiment_dir>` and supporting files must be copied into the repository using the following structure:
+
+```
+auto-discern/
+└── autodiscern/
+    └── pakage_data/
+        ├── predictors/
+        |    └── <experiment_dir>/
+        |         ├── test/
+        |         |    ├── question_4/
+        |         |    |    └── fold_0/
+        |         |    |         └── config/
+        |         |    |             ├── exp_options.pkl
+        |         |    |             └── mconfig.pkl
+        |         |    └── ...
+        |         |    
+        |         └── train_validation/
+        |              ├── question_4/
+        |              |    └── fold_0/
+        |              |         └── model_statedict/
+        |              |             ├── doc_categ_scorer.pkl
+        |              |             └── doc_encoder.pkl
+        |              |             └── sent_encoder.pkl
+        |              └── ...
+        └── pytorch_biobert/
+             ├── bert-base-cased-vocab.txt
+             ├── bert_config.json
+             └── biobert_statedict.pkl
+
+```
+
+Then, in `auto-discern/validator_site/app.py`:
+
+ * Set `DEFAULT_NEURAL_EXP_DIR` to `<experiment_dir>`.
+ * Set `DEFAULT_USE_GPU` to `True` or `False`, depending on whether the machine you will be deploying the model on has GPUs.
+ * If you want to use different folds from the cross validation than the default (fold 0, as shown in the file diagram above), set `DEFAULT_QUESTION_FOLD_MAP` accordingly.
+
+### Deployment with Docker
+
 On your local machine, from within `autodiscern/`:
  1. Build the docker image
  

--- a/autodiscern/package_data/test/test.html
+++ b/autodiscern/package_data/test/test.html
@@ -1,0 +1,904 @@
+
+<!DOCTYPE html>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!--[if lt IE 9]><html class="ie8" lang="en"><![endif]-->
+<!--[if IE 9]><html class="ie9" lang="en"><![endif]-->
+<!--[if gt IE 9]><!--><html lang="en"><!--<![endif]-->
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="Tendons are strong bands or cords of tissue that attach muscle to bone. They help move the bones and joints when muscles contract.">
+    <link rel="canonical" href="https://www.nhs.uk/conditions/tendonitis/">
+
+    
+  <meta name="keywords" content="Tendonitis">
+
+
+    <title>
+  Tendonitis
+ - NHS</title>
+
+    
+      
+    
+
+    <link href="https://assets.nhs.uk/" rel="preconnect" crossorigin>
+    <link type="font/woff2" href="https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.woff2" rel="preload" as="font" crossorigin>
+    <link type="font/woff2" href="https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.woff2" rel="preload" as="font" crossorigin>
+
+    <link rel="stylesheet" href="/static/nhsuk_shared/css/main.6a9c5d90f350.css" type="text/css" />
+
+    
+      
+    
+
+    
+      <script type="application/ld+json">{"@context": "http://schema.org", "@type": "MedicalWebPage", "alternateName": [], "author": {"@type": "Organization", "email": "nhswebsite.servicedesk@nhs.net", "logo": "https://www.nhs.uk/nhscwebservices/documents/logo1.jpg", "name": "NHS website", "url": "https://www.nhs.uk"}, "breadcrumb": {"@context": "http://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "item": {"@id": "https://www.nhs.uk/conditions/", "genre": "condition", "name": "Health A to Z"}, "position": 0}, {"@type": "ListItem", "item": {"@id": "https://www.nhs.uk/conditions/tendonitis/", "genre": "condition", "name": "Tendonitis"}, "position": 1}]}, "copyrightHolder": {"@type": "Organization", "name": "Crown Copyright"}, "dateModified": "2019-07-29T13:48:06+00:00", "description": "Tendons are strong bands or cords of tissue that attach muscle to bone. They help move the bones and joints when muscles contract.", "genre": "condition", "hasPart": [{"@type": "WebPageElement", "description": "Tendonitis is the swelling of a tendon, which is a thick cord attaching a muscle to a bone. It can cause joint pain and stiffness.", "name": "overview", "text": "<p>Symptoms of tendonitis include pain, stiffness and swelling in a joint.</p><p>You can usually treat tendonitis with rest, ice packs, compression and elevation. A GP may prescribe painkillers or recommend physiotherapy.</p><p>Tendonitis is most often caused by sudden movements or repetitive exercise, such as running, jumping or throwing.</p>", "url": "https://www.nhs.uk/conditions/tendonitis/#overview"}, {"@type": "WebPageElement", "description": "You can usually treat tendonitis with rest, ice packs, compression and elevation. A GP may prescribe painkillers or recommend physiotherapy.", "name": "treatments_overview", "text": "", "title": "", "url": "https://www.nhs.uk/conditions/tendonitis/#treatments-summary"}, {"@type": "WebPageElement", "description": "", "name": "self_care", "text": "<p>Follow the 4 steps known as RICE therapy for 2 to 3 days to help bring down swelling and support the injury:</p><ol><li><strong>Rest</strong> \u2013 stop the exercise or activities that caused the injury until you feel better</li><li><strong>Ice</strong> \u2013 put an ice pack (you could use a bag of frozen peas wrapped in a tea towel) on the injury for up to 20 minutes every 2 to 3 hours</li><li><strong>Compress</strong> \u2013 wrap a bandage around the injury to support it</li><li><strong>Elevate</strong> \u2013 if possible, keep the injured area raised on a pillow when sitting or lying down</li></ol><video data-video-id=\"5754933662001\" data-account=\"79855382001\" data-player=\"EkC1XU82e\" data-embed=\"default\" data-application-id class=\"video-js\" controls style=\"position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; width: 100%; height: 100%;\"></video><p>To help prevent swelling during the first 2 to 3 days, try to avoid:</p><ul><li>heat, such as hot baths and heat packs</li><li>alcohol</li><li>massages</li></ul><p>When you can move the injured area without pain stopping you, try to keep moving it so the tendon does not become stiff.</p>", "title": "How to treat tendonitis yourself", "url": "https://www.nhs.uk/conditions/tendonitis/#self-care"}, {"@type": "WebPageElement", "description": "Symptoms of tendonitis include pain, stiffness and swelling in a joint.", "name": "symptoms", "text": "<p>There are tendons all over your body. They connect your muscles to bones, for example in your knees, elbows and shoulders.</p><p>The main symptoms of tendonitis are:</p><ul><li>pain in a tendon (for example, in your knee, elbow or shoulder) that gets worse when you move</li><li>difficulty moving the tendon</li><li>feeling a grating or crackling sensation when you move the tendon</li><li>swelling, sometimes with heat or redness</li><li>a lump along the tendon</li></ul><p>There are many different types of tendonitis, depending on which area of the body is affected.</p>", "title": "Check if it's tendonitis", "url": "https://www.nhs.uk/conditions/tendonitis/#symptoms"}, {"@type": "WebPageElement", "description": "", "name": "other_treatments", "text": "<p>Your doctor may prescribe a stronger painkiller or cream or gel to bring down the swelling.</p><p>If your injury is severe or lasts a long time, you may be offered physiotherapy. You can also choose to book appointments privately.</p><p>You may be referred to hospital for a scan if your doctor thinks you could have another injury, such as a broken bone.</p><p>Some people with long-term or severe tendonitis may be offered:</p><ul><li><a href=\"/conditions/steroid-injections/\">steroid injections</a> \u2013 which may provide short-term pain relief</li><li>surgery \u2013 to remove damaged tissue or repair a ruptured tendon  </li><li>shockwave therapy \u2013 which may help speed up healing   </li><li>platelet rich plasma injections (PRP) \u2013 which may help speed up healing</li></ul>", "title": "Treatment for tendonitis from a GP", "url": "https://www.nhs.uk/conditions/tendonitis/#treatments-other"}, {"@type": "WebPageElement", "description": "Tendonitis is most often caused by sudden movements or repetitive exercise, such as running, jumping or throwing.", "name": "prevention", "text": "<p>Tendonitis is most often caused by sudden, sharp movements or repetitive exercise, such as running, jumping or throwing.</p><p>To help reduce your risk of tendon injuries:</p><br><h3>Do</h3><ul><li>warm up before exercising and stretch afterwards</li><li>wear suitable shoes for exercise</li><li>take regular breaks from repetitive exercises</li></ul><br><h3>Don't</h3><ul><li>do not overexercise tired muscles</li><li>do not start a new sport without some training or practise</li><li>do not stick to the same repetitive exercises</li></ul><p>Tendonitis can also be caused by repetitive movements or having poor posture at work, such as when using a keyboard and mouse. This is known as <a href=\"/conditions/repetitive-strain-injury-rsi/\">repetitive strain injury (RSI)</a>.</p><p><a href=\"/live-well/healthy-body/tips-to-prevent-rsi/\">Read about things you can do to prevent RSI</a></p>", "title": "You cannot always prevent tendonitis", "url": "https://www.nhs.uk/conditions/tendonitis/#prevention"}], "keywords": ["Tendonitis"], "lastReviewed": ["2017-11-09T11:12:00+00:00", "2020-11-09T11:12:00+00:00"], "license": "https://developer.api.nhs.uk/terms", "name": "Tendonitis", "relatedLink": [{"@type": "LinkRole", "linkRelationship": "Navigation", "name": "Tendonitis", "position": 0, "url": "https://www.nhs.uk/conditions/tendonitis/"}], "schemaVersion": "g-20190515", "url": "https://www.nhs.uk/conditions/tendonitis/"}</script>
+    
+
+    <link rel="shortcut icon" href="/static/nhsuk_shared/img/favicons/favicon.68c7f017cfba.ico" type="image/x-icon">
+    <link rel="apple-touch-icon" href="/static/nhsuk_shared/img/favicons/apple-touch-icon-180x180.15a5044def06.png">
+    <link rel="mask-icon" href="/static/nhsuk_shared/img/favicons/favicon.25bc75538faa.svg" color="#005eb8">
+    <link rel="icon" sizes="192x192" href="/static/nhsuk_shared/img/favicons/favicon-192x192.43924bfe6c7e.png">
+    <meta name="msapplication-TileImage" content="/static/nhsuk_shared/img/favicons/mediumtile-144x144.cf4985872492.png">
+    <meta name="msapplication-TileColor" content="#005eb8">
+    <meta name="msapplication-square70x70logo" content="/static/nhsuk_shared/img/favicons/smalltile-70x70.29f75b06cf75.png">
+    <meta name="msapplication-square150x150logo" content="/static/nhsuk_shared/img/favicons/mediumtile-150x150.89688d93af5b.png">
+    <meta name="msapplication-wide310x150logo" content="/static/nhsuk_shared/img/favicons/widetile-310x150.535c3996630d.png">
+    <meta name="msapplication-square310x310logo" content="/static/nhsuk_shared/img/favicons/largetile-310x310.294742e00ff4.png">
+
+    
+
+    
+      <meta property="og:url" content="https://www.nhs.uk/conditions/tendonitis/">
+      <meta property="og:site_name" content="nhs.uk">
+      <meta property="og:title" content="
+  Tendonitis
+"/>
+      <meta property="og:description" content="Tendons are strong bands or cords of tissue that attach muscle to bone. They help move the bones and joints when muscles contract.">
+      <meta property="og:type" content="website">
+      <meta property="og:locale" content="en_GB">
+      <meta property="og:image" content="https://www.nhs.uk/static/shared/img/default-social-image.a74435697f45.png">
+      <meta property="og:image:alt" content="nhs.uk"/>
+      <meta property="article:author" content="https://www.facebook.com/nhswebsite/">
+      <meta property="article:modified_time" content="29 Jul 2019, 1:48 p.m.">
+      <meta property="article:published_time" content="23 Oct 2017, 12:03 p.m.">
+      <meta property="article:section" content="conditions">
+      <meta name="twitter:card" content="summary_large_image">
+      <meta name="twitter:site" content="@nhsuk">
+      <meta name="twitter:creator" content="@nhsuk">
+      <meta name="twitter:image:alt" content="nhs.uk"/>
+    
+
+    
+      <script src="//assets.nhs.uk/scripts/cookie-consent.js"></script>
+    
+
+    
+
+    <script type="application/javascript">window.digitalData=
+            {"page": {
+                "pageInfo": {
+                    "pageName": "nhs:web:conditions:Tendonitis"
+               },
+                "category":
+                    {
+            "primaryCategory": "conditions",
+            "subCategory1":"Tendonitis",
+            "subCategory2":"",
+            "subCategory3":""
+            }
+                },
+               };
+            </script>
+    
+      
+      <script src="//assets.adobedtm.com/launch-ENe7f6cdd7cc05409b86547d9153429788.min.js" type="text/plain" data-cookieconsent="statistics" async></script>
+    
+
+    
+      
+      <script type="text/plain" data-cookieconsent="statistics">
+        (function (h, o, t, j, a, r) {
+          h.hj = h.hj || function () {
+            (h.hj.q = h.hj.q || []).push(arguments)
+          };
+          h._hjSettings = {
+            hjid: 681718,
+            hjsv: 6
+          };
+          a = o.getElementsByTagName('head')[0];
+          r = o.createElement('script');
+          r.async = 1;
+          r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+          a.appendChild(r);
+        })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
+      </script>
+    
+
+    <script>
+      window.NHSUK_SETTINGS = {};
+      window.NHSUK_SETTINGS.BANNER_API_URL = "/externalservices/surveyfeedapi/api/bannerfeed";
+      window.NHSUK_SETTINGS.BANNER_TEST_API_URL = "/externalservices/surveyfeedapi/api/testfeed";
+      window.NHSUK_SETTINGS.SUGGESTIONS_TEST_HOST = "";
+      window.NHSUK_SETTINGS.SEARCH_TEST_HOST = "";
+    </script>
+  </head>
+
+  <body class="">
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
+    
+
+    
+      <a class="nhsuk-skip-link" href="#maincontent">Skip to main content</a>
+
+
+      
+
+
+
+
+<header class="nhsuk-header" role="banner">
+  <div class="nhsuk-width-container nhsuk-header__container">
+    <div class="nhsuk-header__logo">
+      <a class="nhsuk-header__link" href="/" aria-label="NHS homepage">
+        <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
+          <path fill="#fff" d="M0 0h40v16H0z"></path>
+          <path fill="#005eb8" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+          <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
+        </svg>
+      </a>
+    </div>
+    <div class="nhsuk-header__content" id="content-header">
+      <div class="nhsuk-header__menu">
+        <button class="nhsuk-header__menu-toggle" id="toggle-menu" aria-controls="header-navigation" aria-label="Open menu">Menu</button>
+      </div>
+      <div class="nhsuk-header__search">
+        <button class="nhsuk-header__search-toggle" id="toggle-search" aria-controls="search" aria-label="Open search">
+          <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+          </svg>
+          <span class="nhsuk-u-visually-hidden">Search</span>
+        </button>
+        <div class="nhsuk-header__search-wrap" id="wrap-search">
+          <form class="nhsuk-header__search-form" id="search"  action="/search/" method="get" role="search">
+            <label class="nhsuk-u-visually-hidden" for="search-field">Search the NHS website</label>
+            <div class="autocomplete-container" id="autocomplete-container"></div>
+            <input class="nhsuk-search__input" id="search-field" name="q" type="search" placeholder="Search" autocomplete="off">
+            <button class="nhsuk-search__submit" type="submit">
+              <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
+              </svg>
+              <span class="nhsuk-u-visually-hidden">Search</span>
+            </button>
+            <button class="nhsuk-search__close" id="close-search">
+              <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+              </svg>
+              <span class="nhsuk-u-visually-hidden">Close search</span>
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+  <nav class="nhsuk-header__navigation" id="header-navigation" role="navigation" aria-label="Primary navigation" aria-labelledby="label-navigation">
+    <p class="nhsuk-header__navigation-title">
+      <span id="label-navigation">Menu</span>
+      <button class="nhsuk-header__navigation-close" id="close-menu">
+        <svg class="nhsuk-icon nhsuk-icon__close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <path d="M13.41 12l5.3-5.29a1 1 0 1 0-1.42-1.42L12 10.59l-5.29-5.3a1 1 0 0 0-1.42 1.42l5.3 5.29-5.3 5.29a1 1 0 0 0 0 1.42 1 1 0 0 0 1.42 0l5.29-5.3 5.29 5.3a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42z"></path>
+        </svg>
+        <span class="nhsuk-u-visually-hidden">Close menu</span>
+      </button>
+    </p>
+    <ul class="nhsuk-header__navigation-list">
+      <li class="nhsuk-header__navigation-item nhsuk-header__navigation-item--for-mobile">
+        <a class="nhsuk-header__navigation-link" href="/">
+          Home
+          <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+          </svg>
+        </a>
+      </li>
+      
+        
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/Conditions/Pages/hub.aspx">
+              Health A-Z
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+        
+      
+        
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/livewell/Pages/Livewellhub.aspx">
+              Live Well
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+        
+      
+        
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/Conditions/social-care-and-support-guide/Pages/what-is-social-care.aspx">
+              Care and support
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+        
+      
+        
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="/news/">
+              Health news
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+        
+      
+        
+          <li class="nhsuk-header__navigation-item">
+            <a class="nhsuk-header__navigation-link" href="https://www.nhs.uk/service-search">
+              Services near you
+              <svg class="nhsuk-icon nhsuk-icon__chevron-right" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M15.5 12a1 1 0 0 1-.29.71l-5 5a1 1 0 0 1-1.42-1.42l4.3-4.29-4.3-4.29a1 1 0 0 1 1.42-1.42l5 5a1 1 0 0 1 .29.71z"></path>
+              </svg>
+            </a>
+          </li>
+        
+      
+    </ul>
+  </nav>
+</header>
+
+
+    
+
+    
+      
+  <nav class="nhsuk-breadcrumb" aria-label="Breadcrumb">
+    <div class="nhsuk-width-container">
+      <ol class="nhsuk-breadcrumb__list">
+        
+          
+
+<li class="nhsuk-breadcrumb__item">
+  <a href="/" class="nhsuk-breadcrumb__link">Home</a>
+</li>
+
+        
+          
+
+<li class="nhsuk-breadcrumb__item">
+  <a href="/conditions/" class="nhsuk-breadcrumb__link">Health A to Z</a>
+</li>
+
+        
+      </ol>
+
+      <p class="nhsuk-breadcrumb__back">
+        
+          
+
+<a href="/conditions/" class="nhsuk-breadcrumb__backlink">Back to Health A to Z</a>
+
+        
+      </p>
+    </div>
+  </nav>
+
+
+    
+
+    
+
+    <div class="nhsuk-width-container">
+      <main class="nhsuk-main-wrapper" id="maincontent">
+        
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+
+      
+  
+    <h1>Tendonitis</h1>
+  
+
+
+    </div>
+  </div>
+
+  <article>
+    <div class="nhsuk-grid-row">
+      <div class="nhsuk-grid-column-two-thirds">
+
+        
+  
+  
+    
+
+
+  <section>
+    
+
+    
+      
+      <a id="overview"></a>
+    
+
+    
+
+      
+      
+        <p><strong>Tendonitis (such as tennis elbow) is when a tendon swells up and becomes painful after a tendon injury. You can treat mild tendon injuries yourself and should feel better within 2 to 3 weeks.</strong></p>
+
+      
+    
+  </section>
+
+
+  
+    
+
+
+
+  
+    
+
+
+  <section>
+    
+      
+      <a id="things-you-can-try"></a>
+    
+
+    
+      
+      <a id="self-care"></a>
+    
+
+    
+      
+      <h2>How to treat tendonitis yourself</h2>
+    
+
+      
+      
+        <p>Follow the 4 steps known as RICE therapy for 2 to 3 days to help bring down swelling and support the injury:</p>
+
+<ol>
+<li><strong>Rest</strong> – stop the exercise or activities that caused the injury until you feel better</li>
+<li><strong>Ice</strong> – put an ice pack (you could use a bag of frozen peas wrapped in a tea towel) on the injury for up to 20 minutes every 2 to 3 hours</li>
+<li><strong>Compress</strong> – wrap a bandage around the injury to support it</li>
+<li><strong>Elevate</strong> – if possible, keep the injured area raised on a pillow when sitting or lying down</li>
+</ol>
+
+      
+    
+      
+        
+<div class="wag-video">
+  <div style="position: relative; display: block; max-width: 100%;">
+    <div style="padding-top: 56.25%;">
+      <video data-video-id="5754933662001"
+          data-account="79855382001"
+          data-player="EkC1XU82e"
+          data-embed="default"
+          data-application-id
+          class="video-js"
+          controls
+          style="position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; width: 100%; height: 100%;">
+      </video>
+      <script src="//players.brightcove.net/79855382001/EkC1XU82e_default/index.min.js"></script>
+    </div>
+  </div>
+  <div class="wag-video--date">
+    
+    Media last reviewed: 20 March 2018<br>
+    Media review due: 20 March 2021
+  </div>
+</div>
+
+
+      
+    
+      
+        <p>To help prevent swelling during the first 2 to 3 days, try to avoid:</p>
+
+<ul>
+<li>heat, such as hot baths and heat packs</li>
+<li>alcohol</li>
+<li>massages</li>
+</ul>
+
+<p>When you can move the injured area without pain stopping you, try to keep moving it so the tendon does not become stiff.</p>
+
+      
+    
+  </section>
+
+
+  
+    
+
+
+  <section>
+    
+      
+      <a id="how-a-pharmacist-can-help"></a>
+    
+
+    
+
+    
+
+      
+      
+        <h2>A pharmacist can help with tendonitis</h2>
+
+<p>A pharmacist can recommend the best painkiller. This might be tablets or a cream or gel you rub on the skin.</p>
+
+<p>Paracetamol and ibuprofen can help to ease mild pain. Wait for 48 hours after your injury before taking ibuprofen, as it can slow down healing.</p>
+
+      
+    
+      
+        
+
+
+
+<div class="nhsuk-action-link app-action-link">
+  <p><a href="/service-search/pharmacy/locationsearch/10">Find a pharmacy</a></p>
+
+</div>
+
+
+
+      
+    
+  </section>
+
+
+  
+    
+
+
+  <section>
+    
+      
+      <a id="symptoms"></a>
+    
+
+    
+      
+      <a id="symptoms"></a>
+    
+
+    
+      
+      <h2>Check if it&#39;s tendonitis</h2>
+    
+
+      
+      
+        <p>There are tendons all over your body. They connect your muscles to bones, for example in your knees, elbows and shoulders.</p>
+
+<p>The main symptoms of tendonitis are:</p>
+
+<ul>
+<li>pain in a tendon (for example, in your knee, elbow or shoulder) that gets worse when you move</li>
+<li>difficulty moving the tendon</li>
+<li>feeling a grating or crackling sensation when you move the tendon</li>
+<li>swelling, sometimes with heat or redness</li>
+<li>a lump along the tendon</li>
+</ul>
+
+<p>There are many different types of tendonitis, depending on which area of the body is affected.</p>
+
+      
+    
+  </section>
+
+
+  
+    
+
+
+  <section>
+    
+
+    
+
+    
+
+      
+      
+        
+
+
+
+<details class="nhsuk-details">
+  <summary class="nhsuk-details__summary">
+    <span class="nhsuk-details__summary-text">
+    Types of tendonitis
+    </span>
+  </summary>
+  <div class="nhsuk-details__text">
+    <div class="block-markdown"><table>
+<thead>
+<tr>
+  <th>Affected area</th>
+  <th>Possible types of tendonitis</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>Knees</td>
+  <td>Patellar tendonitis (jumper's knee)</td>
+</tr>
+<tr>
+  <td>Elbows</td>
+  <td>Tennis elbow or golfer's elbow</td>
+</tr>
+<tr>
+  <td>Shoulders</td>
+  <td>Calcific tendonitis or supraspinatus tendonitis</td>
+</tr>
+<tr>
+  <td>Wrists and thumbs</td>
+  <td>De Quervain's disease</td>
+</tr>
+<tr>
+  <td>Heels</td>
+  <td>Achilles tendonitis</td>
+</tr>
+<tr>
+  <td>Upper arm</td>
+  <td>Biceps tendonitis</td>
+</tr>
+</tbody>
+</table>
+</div>
+  </div>
+</details>
+
+
+
+
+      
+    
+  </section>
+
+
+  
+    
+
+
+  <section>
+    
+      
+      <a id="when-to-get-medical-help"></a>
+    
+
+    
+
+    
+
+      
+      
+        
+
+
+
+<div class="nhsuk-care-card nhsuk-care-card--non-urgent">
+  <div class="nhsuk-care-card__heading-container">
+    <h3 class="nhsuk-care-card__heading"><span role="text"><span class="nhsuk-u-visually-hidden">Non-urgent advice: </span>Go to a minor injuries unit or your GP if:</span></h3>
+    <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
+  </div>
+  <div class="nhsuk-care-card__content">
+   <ul>
+<li>your symptoms do not improve within a few weeks</li>
+<li>you're in a lot of pain</li>
+<li>you think you have ruptured (torn) a tendon</li>
+</ul>
+
+<p>A ruptured tendon usually causes sudden and severe pain. You might hear a popping or snapping sound during the injury.</p>
+
+<p><a href="/service-search/minor-injuries-unit/locationsearch/551">Find a minor injuries unit</a></p>
+
+    
+  </div>
+</div>
+
+
+
+      
+    
+  </section>
+
+
+  
+    
+
+
+  <section>
+    
+      
+      <a id="treatment-from-a-gp"></a>
+    
+
+    
+      
+      <a id="treatments-other"></a>
+    
+
+    
+      
+      <h2>Treatment for tendonitis from a GP</h2>
+    
+
+      
+      
+        <p>Your doctor may prescribe a stronger painkiller or cream or gel to bring down the swelling.</p>
+
+<p>If your injury is severe or lasts a long time, you may be offered physiotherapy. You can also choose to book appointments privately.</p>
+
+      
+    
+      
+        <p>You may be referred to hospital for a scan if your doctor thinks you could have another injury, such as a broken bone.</p>
+
+<p>Some people with long-term or severe tendonitis may be offered:</p>
+
+<ul>
+<li><a href="/conditions/steroid-injections/">steroid injections</a> – which may provide short-term pain relief</li>
+<li>surgery – to remove damaged tissue or repair a ruptured tendon  </li>
+<li>shockwave therapy – which may help speed up healing   </li>
+<li>platelet rich plasma injections (PRP) – which may help speed up healing</li>
+</ul>
+
+      
+    
+  </section>
+
+
+  
+    
+
+
+  <section>
+    
+
+    
+
+    
+
+      
+      
+        
+
+
+
+<div class="nhsuk-action-link app-action-link">
+  <p><a href="/Service-Search/Physiotherapy/LocationSearch/725">Find a physiotherapist</a></p>
+
+</div>
+
+
+
+      
+    
+  </section>
+
+
+  
+    
+
+
+  <section>
+    
+      
+      <a id="prevention"></a>
+    
+
+    
+      
+      <a id="prevention"></a>
+    
+
+    
+      
+      <h2>You cannot always prevent tendonitis</h2>
+    
+
+      
+      
+        <p>Tendonitis is most often caused by sudden, sharp movements or repetitive exercise, such as running, jumping or throwing.</p>
+
+<p>To help reduce your risk of tendon injuries:</p>
+
+      
+    
+      
+        
+
+
+
+
+<div class="nhsuk-do-dont-list app-check">
+  <h3 class="nhsuk-do-dont-list__label">Do</h3>
+  <ul class="list--check">
+<li>warm up before exercising and stretch afterwards</li>
+<li>wear suitable shoes for exercise</li>
+<li>take regular breaks from repetitive exercises</li>
+</ul>
+
+</div>
+
+<div class="nhsuk-do-dont-list app-cross">
+  <h3 class="nhsuk-do-dont-list__label">Don't</h3>
+  <ul class="list--cross">
+<li>do not overexercise tired muscles</li>
+<li>do not start a new sport without some training or practise</li>
+<li>do not stick to the same repetitive exercises</li>
+</ul>
+
+</div>
+
+
+
+      
+    
+      
+        <p>Tendonitis can also be caused by repetitive movements or having poor posture at work, such as when using a keyboard and mouse. This is known as <a href="/conditions/repetitive-strain-injury-rsi/">repetitive strain injury (RSI)</a>.</p>
+
+<p><a href="/live-well/healthy-body/tips-to-prevent-rsi/">Read about things you can do to prevent RSI</a></p>
+
+      
+    
+  </section>
+
+
+  
+    
+
+
+  <section>
+    
+      
+      <a id="video-tendonitis-an-animation"></a>
+    
+
+    
+
+    
+
+      
+      
+        
+<div class="wag-video">
+  <div style="position: relative; display: block; max-width: 100%;">
+    <div style="padding-top: 56.25%;">
+      <video data-video-id="683476154001"
+          data-account="79855382001"
+          data-player="EkC1XU82e"
+          data-embed="default"
+          data-application-id
+          class="video-js"
+          controls
+          style="position: absolute; top: 0px; right: 0px; bottom: 0px; left: 0px; width: 100%; height: 100%;">
+      </video>
+      <script src="//players.brightcove.net/79855382001/EkC1XU82e_default/index.min.js"></script>
+    </div>
+  </div>
+  <div class="wag-video--date">
+    
+    Media last reviewed: 14 April 2018<br>
+    Media review due: 14 April 2021
+  </div>
+</div>
+
+
+      
+    
+  </section>
+
+
+  
+
+  <div class="nhsuk-review-date">
+    <p class="nhsuk-body-s">
+      Page last reviewed: 9 November 2017<br>
+      Next review due: 9 November 2020
+    </p>
+  </div>
+
+  
+
+
+      </div>
+
+      
+
+    </div>
+  </article>
+
+  
+
+
+      </main>
+    </div>
+
+    
+
+    
+      
+
+
+
+<footer role="contentinfo">
+  <div class="nhsuk-footer" id="nhsuk-footer">
+    <div class="nhsuk-width-container">
+      <h2 class="nhsuk-u-visually-hidden">Support links</h2>
+      <ul class="nhsuk-footer__list nhsuk-footer__list--three-columns">
+        
+          <li class="nhsuk-footer__list-item"><a href="https://www.nhs.uk/nhs-sites/" class="nhsuk-footer__list-item-link">NHS sites</a></li>
+        
+          <li class="nhsuk-footer__list-item"><a href="https://www.nhs.uk/about-us/" class="nhsuk-footer__list-item-link">About us</a></li>
+        
+          <li class="nhsuk-footer__list-item"><a href="https://www.nhs.uk/contact-us/" class="nhsuk-footer__list-item-link">Contact us</a></li>
+        
+          <li class="nhsuk-footer__list-item"><a href="/personalisation/login.aspx" class="nhsuk-footer__list-item-link">Profile editor login</a></li>
+        
+        
+          <li class="nhsuk-footer__list-item"><a href="https://www.nhs.uk/about-us/sitemap/" class="nhsuk-footer__list-item-link">Sitemap</a></li>
+        
+          <li class="nhsuk-footer__list-item"><a href="https://www.nhs.uk/accessibility/" class="nhsuk-footer__list-item-link">Accessibility</a></li>
+        
+          <li class="nhsuk-footer__list-item"><a href="https://www.nhs.uk/our-policies/" class="nhsuk-footer__list-item-link">Our policies</a></li>
+        
+          <li class="nhsuk-footer__list-item"><a href="https://www.nhs.uk/our-policies/cookies-policy/" class="nhsuk-footer__list-item-link">Cookies</a></li>
+        
+      </ul>
+      <p class="nhsuk-footer__copyright">&copy; Crown copyright</p>
+    </div>
+  </div>
+</footer>
+
+
+    
+
+    <script src="/static/nhsuk_shared/js/jquery-3.4.1.11c05eb286ed.js" type="text/javascript"></script>
+    <script src="/static/nhsuk_shared/js/main.a293eb13c434.js" type="text/javascript"></script>
+
+    
+      
+    
+
+  </body>
+</html>
+

--- a/neural/model.py
+++ b/neural/model.py
@@ -439,7 +439,7 @@ def restrict_grad_(mparams, mode, limit):
                 param.grad.data.clamp_(minl, maxl)
 
 
-def generate_sents_embeds_from_docs(docs_data_tensor, bertembeder, embed_dir, fdtype, gpu_index=0):
+def generate_sents_embeds_from_docs(docs_data_tensor, bertembeder, embed_dir, fdtype, to_gpu=True, gpu_index=0):
     """Generate token embedding for sentences in docs
 
     Args:
@@ -447,19 +447,21 @@ def generate_sents_embeds_from_docs(docs_data_tensor, bertembeder, embed_dir, fd
         bertembeder: instance of :class:`BertEmbedder`
         embed_dir: string, path to directory where to dump embedding per document
         fdtype: torch dtype, {torch.float32 or torch.float64}
+        to_gpu: bool, whether to use gpu or cpu
+        gpu_index: if to_gpu, which gpu index to use
 
     """
     bert_proc_docs = {}
-    gpu_device = get_device(to_gpu=True, index=gpu_index)
+    device = get_device(to_gpu=to_gpu, index=gpu_index)
     # move bertembedder to gpu
-    bertembeder.type(fdtype).to(gpu_device)
+    bertembeder.type(fdtype).to(device)
     samples_counter = 0
     num_iter = len(docs_data_tensor)  # number of samples
     for doc_indx in range(num_iter):
         print(doc_indx)
         doc_batch, doc_len, doc_sents_len, doc_attn_mask, doc_labels, doc_id = docs_data_tensor[doc_indx]
         # push to gpu
-        embed_sents = bertembeder(doc_batch.to(gpu_device), doc_attn_mask.to(gpu_device), doc_len.item())
+        embed_sents = bertembeder(doc_batch.to(device), doc_attn_mask.to(device), doc_len.item())
         # write to disk for now
         embed_fpath = os.path.join(embed_dir, '{}.pkl'.format(doc_id))
         ReaderWriter.dump_tensor(embed_sents, embed_fpath)

--- a/neural/predict_with_neural.py
+++ b/neural/predict_with_neural.py
@@ -292,7 +292,9 @@ def make_prediction(url: str, exp_dir=DEFAULT_BIOBERT_EXP_DIR, question_fold_map
 
     html_content = retrieve_page_from_internet(url)
     data_dict = build_data_dict(url, html_content)
-    return biobert_predict(data_dict, QUESTIONS, exp_dir, question_fold_map, to_gpu, gpu_index)
+    raw_predictions = biobert_predict(data_dict, QUESTIONS, exp_dir, question_fold_map, to_gpu, gpu_index)
+    clean_predictions = parse_prediction_results(raw_predictions)
+    return clean_predictions
 
 
 def test_make_prediction(exp_dir=DEFAULT_BIOBERT_EXP_DIR, question_fold_map=None, to_gpu=DEFAULT_USE_GPU, gpu_index=0
@@ -317,17 +319,14 @@ def test_make_prediction(exp_dir=DEFAULT_BIOBERT_EXP_DIR, question_fold_map=None
     with open(test_data_path, 'r') as f:
         html_content = f.read()
     data_dict = build_data_dict(test_article_url, html_content)
-    return biobert_predict(data_dict, QUESTIONS, exp_dir, question_fold_map, to_gpu, gpu_index)
+    raw_predictions = biobert_predict(data_dict, QUESTIONS, exp_dir, question_fold_map, to_gpu, gpu_index)
+    clean_predictions = parse_prediction_results(raw_predictions)
+    return clean_predictions
 
 
 if __name__ == '__main__':
     predictions_dict = test_make_prediction()
-    print("\n\nRAW PREDICTIONS DICT")
-    print(predictions_dict)
-
-    clean_predictions = parse_prediction_results(predictions_dict)
-    print("\n\nCLEAN PREDICTIONS DICT")
-    for q in clean_predictions:
+    for q in predictions_dict:
         print(q)
-        print(clean_predictions[q])
+        print(predictions_dict[q])
         print()

--- a/neural/predict_with_neural.py
+++ b/neural/predict_with_neural.py
@@ -18,7 +18,7 @@ from typing import Dict, List
 QUESTIONS = [4, 5, 9, 10, 11]
 DEFAULT_BASE_DIR = '/opt/data/autodiscern'
 DEFAULT_BIOBERT_EXP_DIR = '2019-10-28_15-59-09'
-DEFAULT_USE_GPU = True
+DEFAULT_USE_GPU = False
 DEFAULT_QUESTION_FOLD_MAP = {
     4: 0,
     5: 0,
@@ -77,14 +77,14 @@ def build_DataDictProcessor(data_dict, vocab_path: str, processor_config: Dict):
     return processor
 
 
-def embed_sentences(docs_data_tensor, sents_embed_path, bertmodel, bert_config, gpu_index):
+def embed_sentences(docs_data_tensor, sents_embed_path, bertmodel, bert_config, to_gpu, gpu_index):
     # from the second notebook
 
     bertembeder = BertEmbedder(bertmodel, bert_config)
     fdtype = torch.float32
 
     # generate and dump bert embedding for the tokens inside the specificed embedding directory
-    bert_proc_docs = generate_sents_embeds_from_docs(docs_data_tensor, bertembeder, sents_embed_path, fdtype,
+    bert_proc_docs = generate_sents_embeds_from_docs(docs_data_tensor, bertembeder, sents_embed_path, fdtype, to_gpu,
                                                      gpu_index=gpu_index)
     ReaderWriter.dump_data(bert_proc_docs, os.path.join(sents_embed_path, 'bert_proc_docs.pkl'))
 
@@ -150,7 +150,7 @@ def biobert_predict(data_dict: dict, questions, experiment_dir, base_dir, questi
 
     # embed sentences
     print("Embedding sentences...")
-    embed_sentences(docs_data_tensor, sents_embed_dir, bertmodel, bert_config, gpu_index)
+    embed_sentences(docs_data_tensor, sents_embed_dir, bertmodel, bert_config, to_gpu, gpu_index)
     print(" ... Finished embedding sentences")
 
     # load model configs

--- a/neural/run_workflow.py
+++ b/neural/run_workflow.py
@@ -690,7 +690,7 @@ def predict_neural_discern(data_partition, bertmodel, config, options, wrk_dir, 
     generic_config = config['generic_config']
     fdtype = generic_config['fdtype']
 
-    class_weights = torch.tensor([1, 1]).type(fdtype).to(device)  # weighting all casess equally
+    class_weights = torch.tensor([1, 1]).type(fdtype).to(device)  # weighting all cases equally
 
     print("class weights", class_weights)
 

--- a/neural/run_workflow.py
+++ b/neural/run_workflow.py
@@ -715,12 +715,14 @@ def predict_neural_discern(data_partition, bertmodel, config, options, wrk_dir, 
                                    bidirection=sentencoder_config['bidirection'],
                                    pdropout=sentencoder_config['pdropout'],
                                    config=sentencoder_config['generic_config'],
+                                   to_gpu=to_gpu,
                                    gpu_index=gpu_index)
 
     # doc encoder model
     attn_model = Attention(attnmodel_config['attn_method'],
                            attnmodel_config['attn_input_dim'],
                            config=attnmodel_config['generic_config'],
+                           to_gpu=to_gpu,
                            gpu_index=gpu_index)
 
     doc_encoder = DocEncoder(docencoder_config['input_dim'],
@@ -730,6 +732,7 @@ def predict_neural_discern(data_partition, bertmodel, config, options, wrk_dir, 
                              bidirection=docencoder_config['bidirection'],
                              pdropout=docencoder_config['pdropout'],
                              config=docencoder_config['generic_config'],
+                             to_gpu=to_gpu,
                              gpu_index=gpu_index)
 
     # doc category scorer
@@ -794,8 +797,7 @@ def predict_neural_discern(data_partition, bertmodel, config, options, wrk_dir, 
                     ReaderWriter.dump_tensor(embed_sents, embed_fpath)
                     bert_proc_docs[doc_id] = embed_fpath
 
-                sents_rnn_hidden = sent_encoder(embed_sents, docs_sents_len[doc_indx],
-                                                docs_len[doc_indx].item())
+                sents_rnn_hidden = sent_encoder(embed_sents, docs_sents_len[doc_indx], docs_len[doc_indx].item())
 
                 # # remove the embedding from GPU
                 # bert_proc_docs[doc_id].to(cpu_device)

--- a/validator_site/app.py
+++ b/validator_site/app.py
@@ -6,11 +6,27 @@ import autodiscern.transformations as adt
 import autodiscern.annotations as ada
 import autodiscern.model as adm
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
+from neural.predict_with_neural import make_prediction
 import inspect
 import pickle
 import requests
 
-PREDICTOR_FILE_PATH = 'data/models/2019_06_14_doc_models_important_qs.pkl'
+NEURAL = True
+
+# Traditional RF Model Configs
+RF_MODEL_PREDICTOR_FILE_PATH = 'data/models/2019_06_14_doc_models_important_qs.pkl'
+
+# Neural (BioBERT) Model Configs
+DEFAULT_NEURAL_BASE_DIR = 'data/models'
+DEFAULT_NEURAL_EXP_DIR = '2019-10-28_15-59-09'
+DEFAULT_USE_GPU = False
+DEFAULT_QUESTION_FOLD_MAP = {
+    4: 0,
+    5: 0,
+    9: 0,
+    10: 0,
+    11: 0,
+}
 
 
 def create_app(test_config=None):
@@ -36,7 +52,7 @@ def create_app(test_config=None):
     package_dir = os.path.abspath(os.path.dirname(os.path.dirname(this_file_path)))
     dm = ad.DataManager(package_dir)
 
-    predictor_filepath = os.path.join(package_dir, PREDICTOR_FILE_PATH)
+    predictor_filepath = os.path.join(package_dir, RF_MODEL_PREDICTOR_FILE_PATH)
     with open(predictor_filepath, "rb+") as f:
         ems = pickle.load(f)
 
@@ -51,7 +67,10 @@ def create_app(test_config=None):
     @app.route('/validate', methods=['POST'])
     def validate():
         url = flask.request.form["url"]
-        predictions = make_prediction(predictors, url)
+        if NEURAL:
+            predictions = make_neural_prediction(url)
+        else:
+            predictions = make_rf_prediction(predictors, url)
         return flask.render_template('index.html', url_str=url, predictions=predictions)
 
     @app.route('/test', methods=['POST'])
@@ -68,7 +87,16 @@ def create_app(test_config=None):
         }
         return flask.render_template('index.html', url_str=url, predictions=predictions)
 
-    def make_prediction(predictors, url: str):
+    def make_neural_prediction(url: str, exp_dir=DEFAULT_NEURAL_EXP_DIR, base_dir=DEFAULT_NEURAL_BASE_DIR,
+                               question_fold_map=None, to_gpu=DEFAULT_USE_GPU, gpu_index=0):
+        prediction = make_prediction(url, exp_dir=exp_dir, base_dir=base_dir, question_fold_map=question_fold_map,
+                                     to_gpu=to_gpu, gpu_index=gpu_index)
+
+        # process predictions here
+
+        return prediction
+
+    def make_rf_prediction(predictors, url: str):
         # load the webpage content
         res = requests.get(url)
         html_page = res.content.decode("utf-8")

--- a/validator_site/app.py
+++ b/validator_site/app.py
@@ -17,7 +17,6 @@ NEURAL = True
 RF_MODEL_PREDICTOR_FILE_PATH = 'data/models/2019_06_14_doc_models_important_qs.pkl'
 
 # Neural (BioBERT) Model Configs
-DEFAULT_NEURAL_BASE_DIR = 'data/models'
 DEFAULT_NEURAL_EXP_DIR = '2019-10-28_15-59-09'
 DEFAULT_USE_GPU = False
 DEFAULT_QUESTION_FOLD_MAP = {
@@ -87,14 +86,24 @@ def create_app(test_config=None):
         }
         return flask.render_template('index.html', url_str=url, predictions=predictions)
 
-    def make_neural_prediction(url: str, exp_dir=DEFAULT_NEURAL_EXP_DIR, base_dir=DEFAULT_NEURAL_BASE_DIR,
-                               question_fold_map=None, to_gpu=DEFAULT_USE_GPU, gpu_index=0):
-        prediction = make_prediction(url, exp_dir=exp_dir, base_dir=base_dir, question_fold_map=question_fold_map,
-                                     to_gpu=to_gpu, gpu_index=gpu_index)
+    def make_neural_prediction(url: str, exp_dir=DEFAULT_NEURAL_EXP_DIR, question_fold_map=None, to_gpu=DEFAULT_USE_GPU,
+                               gpu_index=0):
+        predictions = make_prediction(url, exp_dir=exp_dir, question_fold_map=question_fold_map, to_gpu=to_gpu,
+                                      gpu_index=gpu_index)
 
-        # process predictions here
+        predictions_to_display = {}
+        for q in predictions:
+            predictions_to_display[q] = {}
+            predictions_to_display[q]['question'] = "Q{}: {}".format(q, adm.questions[q])
+            if predictions[q]['pred_class'] == 1:
+                predictions_to_display[q]['answer'] = 'Yes'
+                predictions_to_display[q]['sentences'] = predictions[q]['sentences']
+            elif predictions[q]['pred_class'] == 0:
+                predictions_to_display[q]['answer'] = 'No'
+            else:
+                predictions_to_display[q]['answer'] = 'Unknown'
 
-        return prediction
+        return predictions_to_display
 
     def make_rf_prediction(predictors, url: str):
         # load the webpage content


### PR DESCRIPTION
* Added `to_gpu` parameter to `generate_sents_embeds_from_docs`.

* Implemented already existing `to_gpu` parameters in the `inits` for `SentenceEncoder`, `DocEncoder`, `Attention` in `run_workflow()`. 

* Created canonical place for model and BioBERT files to live, so they can be referenced the same way on any machine where autoDiscern is running. See the updates to `README` for a description of the file structure. These files are accessed in the code using:

      `sents_embed_dir = pkg_resources.resource_filename('autodiscern', 'package_data/pytorch_biobert')`

   For now these files are excluded by the `.gitignore` because they are quite large for a git repo, so folks would have to download them and put them in place :/ I might change my mind on that though in the future... 